### PR TITLE
Changed deprecated MAINTAINER to LABEL

### DIFF
--- a/ubuntu-minjava-build/Dockerfile
+++ b/ubuntu-minjava-build/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:16.04
 
-MAINTAINER Paul T. Barham <pabarham@microsoft.com>
+LABEL maintainer="Paul T. Barham <pabarham@microsoft.com>"
 
 LABEL version="RC2"
 LABEL description="An Ubuntu 16 VM with Java developer tools and Team Services coreCLR build agent"

--- a/ubuntu-xplat-build/Dockerfile
+++ b/ubuntu-xplat-build/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM javaalm/vsts-ubuild-minjava
 
-MAINTAINER Paul T. Barham <pabarham@microsoft.com>
+LABEL maintainer="Paul T. Barham <pabarham@microsoft.com>"
 
 LABEL version="RC2"
 LABEL description="An Ubuntu 16 VM with cross-platform developer tools and Team Services coreCLR build agent"


### PR DESCRIPTION
Docker documentation states that MAINTAINER is deprecated and LABEL should be used to add author metadata in future Docker files.
Source: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated